### PR TITLE
Fixes for macOS

### DIFF
--- a/ezxml/ezxml.c
+++ b/ezxml/ezxml.c
@@ -363,7 +363,8 @@ short ezxml_internal_dtd(ezxml_root_t root, char *s, size_t len)
             else *s = '\0'; // null terminate tag name
             for (i = 0; root->attr[i] && strcmp(n, root->attr[i][0]); i++);
 
-            while (*(n = ++s + strspn(s, EZXML_WS)) && *n != '>') {
+            ++s;
+            while (*(n = s + strspn(s, EZXML_WS)) && *n != '>') {
                 if (*(s = n + strcspn(n, EZXML_WS))) *s = '\0'; // attr name
                 else { ezxml_err(root, t, "malformed <!ATTLIST"); break; }
 

--- a/main.c
+++ b/main.c
@@ -907,6 +907,49 @@ void clear_dir(char *path)
     remove(path);
 }
 
+//Function to iterate through a blacklist of file name patterns, to stop normally hidden files from being copied to the FST.
+//List retrieved from https://www.gitignore.io/api/macos%2Clinux%2Cwindows
+bool isIgnoredFile(char *fileName)
+{
+    if(strncmp(fileName, ".fuse_hidden", 12) == 0) return true;
+    if(strcmp(fileName, ".directory") == 0) return true;
+    if(strncmp(fileName, ".Trash-", 7) == 0) return true;
+    if(strncmp(fileName, ".nfs", 4) == 0) return true;
+    if(strcmp(fileName, ".DS_Store") == 0) return true;
+    if(strcmp(fileName, ".AppleDouble") == 0) return true;
+    if(strcmp(fileName, ".LSOverride") == 0) return true;
+    if(strcmp(fileName, "Icon\r\r") == 0) return true;
+    if(strncmp(fileName, "._", 2) == 0) return true;
+    if(strcmp(fileName, ".DocumentRevisions-V100") == 0) return true;
+    if(strcmp(fileName, ".fseventsd") == 0) return true;
+    if(strcmp(fileName, ".Spotlight-V100") == 0) return true;
+    if(strcmp(fileName, ".TemporaryItems") == 0) return true;
+    if(strcmp(fileName, ".Trashes") == 0) return true;
+    if(strcmp(fileName, ".VolumeIcon.icns") == 0) return true;
+    if(strcmp(fileName, ".com.apple.timemachine.donotpresent") == 0) return true;
+    if(strcmp(fileName, ".AppleDB") == 0) return true;
+    if(strcmp(fileName, ".AppleDesktop") == 0) return true;
+    if(strcmp(fileName, "Network Trash Folder") == 0) return true;
+    if(strcmp(fileName, "Temporary Items") == 0) return true;
+    if(strcmp(fileName, ".apdisk") == 0) return true;
+    if(strcmp(fileName, "Thumbs.db") == 0) return true;
+    if(strcmp(fileName, "ehthumbs.db") == 0) return true;
+    if(strcmp(fileName, "ehthumbs_vista.db") == 0) return true;
+    if(strcmp(fileName, "Desktop.ini") == 0) return true;
+    if(strcmp(fileName, "$RECYCLE.BIN") == 0) return true;
+    
+    if((strlen(fileName) - 4) > 0)
+    {
+        if(strcmp(&fileName[strlen(fileName) - 4], ".cab") == 0) return true;
+        if(strcmp(&fileName[strlen(fileName) - 4], ".msi") == 0) return true;
+        if(strcmp(&fileName[strlen(fileName) - 4], ".msm") == 0) return true;
+        if(strcmp(&fileName[strlen(fileName) - 4], ".msp") == 0) return true;
+        if(strcmp(&fileName[strlen(fileName) - 4], ".lnk") == 0) return true;
+    }
+    
+    return false;
+}
+
 int get_num_entries(char *dir, u8 filesOnly)
 {
     DIR *dfd;
@@ -929,6 +972,8 @@ int get_num_entries(char *dir, u8 filesOnly)
             printf("Unable to stat file: %s\n", temp) ;
             continue ;
         }
+        
+        if(isIgnoredFile(dp->d_name)) continue;
 
         if ( ( stbuf.st_mode & S_IFMT ) == S_IFDIR )
         {
@@ -973,6 +1018,8 @@ int get_entries(char *dir, char **out_dirs, u32 *out_sizes, u32 *out_parent_dir,
             printf("Unable to stat file: %s\n", temp) ;
             continue ;
         }
+        
+        if(isIgnoredFile(dp->d_name)) continue;
 
         if ( ( stbuf.st_mode & S_IFMT ) == S_IFDIR )
         {


### PR DESCRIPTION
macOS does things a little differently in terms of copying string buffers. On Linux/Windows, you can copy a source buffer to a destination buffer, even if they overlap, as long as the source buffer is after the destination buffer.

But ISO had not defined a standard reaction to this kind of event, and as such, Apple's implementation of libc aborts if the two buffers overlap each other. I resolve this by allocating a temporary buffer and using that to perform string operations.

I have also suppressed some compiler warnings, and added checks to filter out normally hidden files (files that shouldn't be included in the FST, such as thumbnails, lock files, etc.) which are often another source of segmentation faults on macOS.

This PR potentially resolves #2.

NOTE: I have not tested these changes on a Linux/Windows setup, and am unsure if I have broken anything on those platforms.